### PR TITLE
Fix random delete in mutation User delete 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+/node_modules
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,11 +1789,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1806,15 +1808,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1917,7 +1922,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1927,6 +1933,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1939,17 +1946,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1966,6 +1976,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2038,7 +2049,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2048,6 +2060,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2153,6 +2166,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/mutations.js
+++ b/src/mutations.js
@@ -170,13 +170,13 @@ const resolvers = {
             return user    
     },
     deleteUser(parent,args,ctx,info){
-        const isUserExists = users.findIndex((user)=> user.id === args.author)
+        const userIndex = users.findIndex((user)=> user.id === args.author)
 
-        if(!isUserExists){
+        if(!userIndex || userIndex < 0){
             throw new Error('User does not exist!')
         }
         //splice will return the removed items from the array object
-        const userdeleted = users.splice(isUserExists, 1)
+        const userdeleted = users.splice(userIndex, 1)
        return userdeleted[0]
     },
     createPost(parent,args,ctx,info){


### PR DESCRIPTION
## Issue
1. Fixes #1 
2. Stop deleting random users in `deleteUser` mutation: 
`users.findIndex(..)` returns `-1` if the user is not found so the ` if(!isUserExists)` check doesn't throw errors correctly and users can be removed unexpectedly even if the query's id doesn't exist.

## Solution
Add an extra check if the `findIndex(...)` result is less than 0